### PR TITLE
Fix Authorization header for bearer token types

### DIFF
--- a/src/oauth2c.erl
+++ b/src/oauth2c.erl
@@ -288,6 +288,10 @@ add_auth_header(Headers, #client{grant_type = <<"azure_client_credentials">>,
                                  access_token = AccessToken}) ->
     AH = {<<"Authorization">>, <<"bearer ", AccessToken/binary>>},
     [AH | proplists:delete(<<"Authorization">>, Headers)];
+add_auth_header(Headers, #client{token_type = bearer,
+                                 access_token = AccessToken}) ->
+    AH = {<<"Authorization">>, <<"bearer ", AccessToken/binary>>},
+    [AH | proplists:delete(<<"Authorization">>, Headers)];
 add_auth_header(Headers, #client{access_token = AccessToken}) ->
     AH = {<<"Authorization">>, <<"token ", AccessToken/binary>>},
     [AH | proplists:delete(<<"Authorization">>, Headers)].


### PR DESCRIPTION
The "Authorization: bearer ..." header for bearer token types was broken with the introduction of support for Azure OAuth, and was incorrectly set to 'Authorization: token ...'. This PR fixes that.