### PR TITLE
fix: allow use of return_maps in options

### DIFF
--- a/src/oauth2c.erl
+++ b/src/oauth2c.erl
@@ -218,7 +218,8 @@ ensure_client_has_access_token(Client0, Options) ->
       Client0
   end.
 
-do_retrieve_access_token(Client, Opts) ->
+do_retrieve_access_token(Client, Opts0) ->
+  Opts = Opts0 -- [return_maps], %% Make sure we get a proplist
   #{headers := RequestHeaders,
     body := RequestBody} = prepare_token_request(Client, Opts),
   case restc:request(post, percent, Client#client.auth_url,


### PR DESCRIPTION
Make it so that giving the `return_maps` option does not crash.